### PR TITLE
Unify and parameterize build scripts

### DIFF
--- a/Generate Backends/Linux/build.sh
+++ b/Generate Backends/Linux/build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -e
+
+# Unified llama.cpp build script for LM Studio backends (Linux)
+# Usage: ./build.sh <backend> [llama_src_dir]
+#   backend: cpu, vulkan, cuda
+#   llama_src_dir: path to llama.cpp source (default: current directory)
+#
+# Examples:
+#   ./build.sh cpu
+#   ./build.sh vulkan /home/user/llama.cpp
+#   ./build.sh cuda
+
+BACKEND="${1}"
+SRC_DIR="${2:-.}"
+
+if [ -z "$BACKEND" ]; then
+    echo "Usage: ./build.sh <backend> [llama_src_dir]"
+    echo "  backend: cpu, vulkan, cuda"
+    exit 1
+fi
+
+case "$BACKEND" in
+    cpu|vulkan|cuda) ;;
+    *) echo "[ERROR] Unknown backend '$BACKEND'. Must be one of: cpu, vulkan, cuda"; exit 1 ;;
+esac
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "[ERROR] Source directory '$SRC_DIR' does not exist."
+    exit 1
+fi
+
+cd "$SRC_DIR"
+
+BUILD_DIR="build-${BACKEND}"
+
+# Common CMake flags
+CMAKE_FLAGS=(
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DCMAKE_BUILD_TYPE=Release
+    -DGGML_AVX=ON
+    -DGGML_AVX2=OFF
+    -DGGML_FMA=OFF
+)
+
+# Backend-specific flags
+case "$BACKEND" in
+    vulkan)
+        CMAKE_FLAGS+=(
+            -DGGML_VULKAN=ON
+            -DGGML_VULKAN_MXFP=OFF
+        )
+        ;;
+    cuda)
+        CMAKE_FLAGS+=(
+            -DUSE_CUDA=ON
+            -DGGML_CUDA=ON
+            -DCUDA_ARCH_LIST=35
+        )
+        ;;
+esac
+
+echo "[INFO] Building $BACKEND backend in $BUILD_DIR"
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+cmake .. "${CMAKE_FLAGS[@]}"
+cmake --build . -j"$(nproc)"
+
+echo "[SUCCESS] $BACKEND backend built successfully in $BUILD_DIR/bin"

--- a/Generate Backends/Linux/readme.md
+++ b/Generate Backends/Linux/readme.md
@@ -11,21 +11,25 @@ sudo pacman -S base-devel gcc cmake git python python-pip \
   libx11 libxrandr libxcursor libxi libxxf86vm
 ```
 
-## Build with Vulkan
+## Build
+
+Use the unified build script:
 
 ```bash
-mkdir build-vulkan
-cd build-vulkan
+# Vulkan backend
+./build.sh vulkan
 
-cmake .. \
-  -DLLAMA_BUILD_EXAMPLES=OFF \
-  -DLLAMA_BUILD_TESTS=OFF \
-  -DLLAMA_BUILD_TOOLS=OFF \
-  -DGGML_VULKAN=ON \
-  -DGGML_VULKAN_MXFP=OFF
+# CPU-only backend
+./build.sh cpu
 
-cmake --build . -j$(nproc)
+# CUDA backend
+./build.sh cuda
+
+# With a custom llama.cpp source directory
+./build.sh vulkan /path/to/llama.cpp
 ```
+
+The old `build_vulkan.sh` script is still available if you prefer it.
 
 ## Why MXFP4 is disabled
 

--- a/Generate Backends/Windows/build.cmd
+++ b/Generate Backends/Windows/build.cmd
@@ -1,0 +1,99 @@
+@echo off
+setlocal
+
+REM =========================
+REM Unified llama.cpp build script for LM Studio backends
+REM Usage: build.cmd <backend> [llama_src_dir]
+REM   backend: cpu, vulkan, cuda
+REM   llama_src_dir: path to llama.cpp source (optional)
+REM
+REM Examples:
+REM   build.cmd cpu
+REM   build.cmd vulkan C:\source\llama.cpp
+REM   build.cmd cuda
+REM =========================
+
+REM --- Parse backend type ---
+set "BACKEND=%~1"
+if "%BACKEND%"=="" (
+    echo Usage: build.cmd ^<backend^> [llama_src_dir]
+    echo   backend: cpu, vulkan, cuda
+    echo   llama_src_dir: path to llama.cpp source ^(optional^)
+    exit /b 1
+)
+
+if /i not "%BACKEND%"=="cpu" if /i not "%BACKEND%"=="vulkan" if /i not "%BACKEND%"=="cuda" (
+    echo [ERROR] Unknown backend "%BACKEND%". Must be one of: cpu, vulkan, cuda
+    exit /b 1
+)
+
+REM --- Parse source directory ---
+set "DEFAULT_SRC_DIR=C:\Users\Admin\source\llama.cpp"
+
+if "%~2"=="" (
+    set "SRC_DIR=%DEFAULT_SRC_DIR%"
+) else (
+    set "SRC_DIR=%~2"
+)
+
+if not exist "%SRC_DIR%" (
+    echo [ERROR] Source directory "%SRC_DIR%" does not exist.
+    exit /b 1
+)
+
+pushd "%SRC_DIR%" >nul 2>&1 || (
+    echo [ERROR] Failed to enter "%SRC_DIR%".
+    exit /b 1
+)
+
+REM -------------------------
+REM Set build dir and compiler flags
+REM -------------------------
+if /i "%BACKEND%"=="cpu"    set "BUILD_DIR=build_cpu"
+if /i "%BACKEND%"=="vulkan" set "BUILD_DIR=build_gpu_vulkan"
+if /i "%BACKEND%"=="cuda"   set "BUILD_DIR=build_gpu_cuda"
+
+set "CL=/bigobj %CL% /Ot /fp:fast"
+
+if exist "%BUILD_DIR%" (
+    echo [INFO] Removing old build directory "%BUILD_DIR%"...
+    rmdir /s /q "%BUILD_DIR%"
+    if errorlevel 1 (
+        echo [ERROR] Failed to remove dir
+        popd
+        pause
+        exit /b 1
+    )
+)
+
+REM -------------------------
+REM Build backend-specific CMake flags
+REM -------------------------
+set "EXTRA_FLAGS="
+if /i "%BACKEND%"=="vulkan" set "EXTRA_FLAGS=-DGGML_VULKAN=ON"
+if /i "%BACKEND%"=="cuda"   set "EXTRA_FLAGS=-DUSE_CUDA=ON -DGGML_CUDA=ON -DCUDA_ARCH_LIST=35"
+
+REM -------------------------
+REM Configure with CMake
+REM -------------------------
+echo [INFO] Building %BACKEND% backend in "%BUILD_DIR%"
+
+cmake -S . -B "%BUILD_DIR%" ^
+      -G "Ninja" ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DLLAMA_CURL=OFF ^
+      -DGGML_NATIVE=ON ^
+      %EXTRA_FLAGS%
+
+cmake --build "%BUILD_DIR%" --verbose
+
+if errorlevel 1 (
+    echo [ERROR] CMake build failed
+    popd
+    pause
+    exit /b 1
+)
+
+echo [SUCCESS] %BACKEND% backend built successfully in "%BUILD_DIR%"
+popd
+exit /b 0

--- a/Generate Backends/Windows/readme.txt
+++ b/Generate Backends/Windows/readme.txt
@@ -11,12 +11,23 @@ B: Steps to Build and Update Backend:
 
 1. Open the "x64 Native Tools Command Prompt for VS 2019" (or whichever one you use).
 
-2. Run the fetch script
+2. Run the fetch script:
+   fetch_llama.cmd
 
-3. Run the build script of your choice using desired flags (for example, no avx or avx 512 and all cuda versions etc etc)
-   Stock Flags: 
+3. Run the unified build script with the backend you want:
+   build.cmd cpu
+   build.cmd vulkan
+   build.cmd cuda
+
+   You can also pass a custom llama.cpp source directory:
+   build.cmd vulkan C:\path\to\llama.cpp
+
+   The individual build_cpu.cmd, build_gpu_vulkan.cmd, and build_gpu_cuda.cmd
+   scripts are still available if you prefer them.
+
+   Stock Flags (set automatically by build.cmd):
    - native (already optimized for your system)
-   - DCUDA_ARCH_LIST=35 (this is for the kepler cards I am debugging, on, use newer ones ideally) 
+   - DCUDA_ARCH_LIST=35 (this is for the kepler cards I am debugging on, use newer ones ideally)
 
 4. Once the build completes, go to the build output folder and copy the following files:
    - ggml-base.dll

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@
 - 🚧 `cuda` — coming soon
 
 ## Custom Backends for your System 🚀 ?
-- Follow the instructions in `Generate Backends`. Windows confirmed working, (Arch) Linux experimental, patches with MXFP4 required.
+- Follow the instructions in `Generate Backends`. Use the unified `build.cmd` (Windows) or `build.sh` (Linux) script:
+  ```
+  build.cmd cpu|vulkan|cuda [llama_src_dir]
+  ./build.sh cpu|vulkan|cuda [llama_src_dir]
+  ```
+- Windows confirmed working, (Arch) Linux experimental, patches with MXFP4 required.
   
 **NOTE** : To save time building, on newer Windoes versions Vulkan backend is already built without AVX2 so patching it is and **confirmed working**. This is likely to work on CUDA gpus as well however is untested at the monent. (Patch in the manifest json file)
 ```


### PR DESCRIPTION
The three Windows build scripts (build_cpu.cmd, build_gpu_vulkan.cmd, build_gpu_cuda.cmd) share ~90% of their CMake flags. 
A single script with a parameter (e.g., build.cmd cpu|vulkan|cuda) would reduce duplication and make maintenance easier.